### PR TITLE
Mapping

### DIFF
--- a/bp-trapp.php
+++ b/bp-trapp.php
@@ -136,3 +136,8 @@ add_filter('bp_trapp_translation_groups', function($translationGroups) {
 
     return $translationGroups;
 });
+
+add_action('bp_trapp_after_save_post_thumbnail', function($translationThumbnailId, $thumbnailId) {
+    // Amazon S3
+    add_post_meta($translationThumbnailId, 'amazonS3_info', get_post_meta($thumbnailId, 'amazonS3_info', true));
+}, 10, 2);

--- a/bp-trapp.php
+++ b/bp-trapp.php
@@ -118,3 +118,21 @@ add_filter('bp_trapp_service_development', function ($is_development) {
 
     return true;
 });
+
+add_filter('bp_trapp_post_types', function($post_types) {
+    $post_types[] = 'review';
+
+    return $post_types;
+});
+
+add_filter('bp_trapp_translation_groups', function($translationGroups) {
+    if (array_key_exists('post_thumbnail', $translationGroups)) {
+        $translationGroups['post_thumbnail']['title'] = 'Product Image';
+
+        foreach ($translationGroups['post_thumbnail']['fields'] as $key => $field) {
+            $translationGroups['post_thumbnail']['fields'][$key]['label'] = str_replace( 'Post Thumbnail', 'Product Image', $field['label'] );
+        }
+    }
+
+    return $translationGroups;
+});

--- a/bp-trapp.php
+++ b/bp-trapp.php
@@ -118,26 +118,3 @@ add_filter('bp_trapp_service_development', function ($is_development) {
 
     return true;
 });
-
-add_filter('bp_trapp_post_types', function($post_types) {
-    $post_types[] = 'review';
-
-    return $post_types;
-});
-
-add_filter('bp_trapp_translation_groups', function($translationGroups) {
-    if (array_key_exists('post_thumbnail', $translationGroups)) {
-        $translationGroups['post_thumbnail']['title'] = 'Product Image';
-
-        foreach ($translationGroups['post_thumbnail']['fields'] as $key => $field) {
-            $translationGroups['post_thumbnail']['fields'][$key]['label'] = str_replace( 'Post Thumbnail', 'Product Image', $field['label'] );
-        }
-    }
-
-    return $translationGroups;
-});
-
-add_action('bp_trapp_after_save_post_thumbnail', function($translationThumbnailId, $thumbnailId) {
-    // Amazon S3
-    add_post_meta($translationThumbnailId, 'amazonS3_info', get_post_meta($thumbnailId, 'amazonS3_info', true));
-}, 10, 2);

--- a/src/Bonnier/WP/Trapp/Admin/Main.php
+++ b/src/Bonnier/WP/Trapp/Admin/Main.php
@@ -161,13 +161,11 @@ class Main
             return;
         }
 
-        global $polylang;
-
-        if (!$polylang->model->get_post_language($postId)) {
+        if (!Pll()->model->post->get_language($postId)) {
             return;
         }
 
         // We will handle the translations instead of Polylang
-        remove_action('save_post', array($polylang->filters_post, 'save_post'), 21, 3);
+        remove_action('save_post', array(Pll()->filters_post, 'save_post'), 21, 3);
     }
 }

--- a/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
@@ -102,7 +102,6 @@ class Events
 
             $thumbnailId = get_post_thumbnail_id($this->post->ID);
             $thumbnailPost = get_post($thumbnailId);
-            // $new_lang = lang
 
             // Check if the translations already exists
             if ($translation = $polylang->model->get_translation('post', $thumbnailId, $language_slug)) {
@@ -121,9 +120,6 @@ class Events
             add_post_meta($translationThumbnailId, '_wp_attached_file', get_post_meta($thumbnailId, '_wp_attached_file', true));
             add_post_meta($translationThumbnailId, '_wp_attachment_image_alt', get_post_meta($thumbnailId, '_wp_attachment_image_alt', true));
 
-            // Amazon S3
-            add_post_meta($translationThumbnailId, 'amazonS3_info', get_post_meta($thumbnailId, 'amazonS3_info', true));
-
             $mediaTranslations = $polylang->model->get_translations('post', $thumbnailId);
 
             if (!$mediaTranslations && $lang = $polylang->model->get_post_language($thumbnailId)) {
@@ -134,6 +130,8 @@ class Events
 
             pll_save_post_translations($mediaTranslations);
             update_post_meta($translations[$language_slug], '_thumbnail_id', $translationThumbnailId);
+
+            do_action('bp_trapp_after_save_post_thumbnail', $translationThumbnailId, $thumbnailId);
         }
 
         pll_save_post_translations($translations);

--- a/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
@@ -128,7 +128,7 @@ class Events
 
         // Check if the translations already exists
         if ($translation = $polylang->model->get_translation('post', $image['id'], $languageSlug)) {
-            update_post_meta($translationId, $image['key'], $translation);
+            return update_post_meta($translationId, $image['key'], $translation);
         }
 
         $translationImagePost = $image['post'];

--- a/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
@@ -70,9 +70,7 @@ class Events
      */
     public function saveLanguages()
     {
-        global $polylang;
-
-        $translations = $polylang->model->get_translations('post', $this->post->ID);
+        $translations = pll_get_post_translations($this->post->ID);
 
         foreach ($this->rowTranslations as $locale => $translation) {
             // Polylang is using the slug to set post languages
@@ -124,10 +122,8 @@ class Events
     }
 
     public function saveImage($translationId, $languageSlug, $image) {
-        global $polylang;
-
         // Check if the translations already exists
-        if ($translation = $polylang->model->get_translation('post', $image['id'], $languageSlug)) {
+        if ($translation = Pll()->model->post->get_translation($image['id'], $languageSlug)) {
             return update_post_meta($translationId, $image['key'], $translation);
         }
 
@@ -143,9 +139,9 @@ class Events
         add_post_meta($translationImageId, '_wp_attached_file', get_post_meta($image['id'], '_wp_attached_file', true));
         add_post_meta($translationImageId, '_wp_attachment_image_alt', get_post_meta($image['id'], '_wp_attachment_image_alt', true));
 
-        $mediaTranslations = $polylang->model->get_translations('post', $image['id']);
+        $mediaTranslations = Pll()->model->post->get_translations($image['id']);
 
-        if (!$mediaTranslations && $lang = $polylang->model->get_post_language($image['id'])) {
+        if (!$mediaTranslations && $lang = Pll()->model->post->get_language($image['id'])) {
             $mediaTranslations[$lang->slug] = $image['id'];
         }
 
@@ -154,6 +150,6 @@ class Events
         pll_save_post_translations($mediaTranslations);
         update_post_meta($translationId, $image['key'], $translationImageId);
 
-        do_action('bp_trapp_after_save_post_image', $translationImageId, $image['id']);
+        do_action('bp_trapp_after_save_post_image', $translationImageId, $image);
     }
 }

--- a/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Polylang/Events.php
@@ -76,64 +76,84 @@ class Events
 
         foreach ($this->rowTranslations as $locale => $translation) {
             // Polylang is using the slug to set post languages
+            $languageSlug = current(explode('_', $locale));
 
-            $language_slug = current(explode('_', $locale));
-
-            if (!array_key_exists($language_slug, $translations)) {
+            if (!array_key_exists($languageSlug, $translations)) {
                 $lang_post_args = apply_filters('bp_trapp_save_language_post_args', [
                     'post_title' => $this->post->post_title,
                     'post_content' => $this->post->post_content,
                     'post_type' => $this->post->post_type,
-                ], $this->post, $language_slug);
+                ], $this->post, $languageSlug);
 
-                $lang_post_id = wp_insert_post($lang_post_args);
-                pll_set_post_language($lang_post_id, $language_slug);
+                $langPostId = wp_insert_post($lang_post_args);
+                pll_set_post_language($langPostId, $languageSlug);
 
-                $translations[$language_slug] = $lang_post_id;
+                $translations[$languageSlug] = $langPostId;
             }
 
             // Update the meta key
-            update_post_meta($translations[$language_slug], Post\Events::TRAPP_META_KEY, $translation['id']);
-            update_post_meta($translations[$language_slug], Post\Events::TRAPP_META_LINK, $translation['edit_uri']);
+            update_post_meta($translations[$languageSlug], Post\Events::TRAPP_META_KEY, $translation['id']);
+            update_post_meta($translations[$languageSlug], Post\Events::TRAPP_META_LINK, $translation['edit_uri']);
 
-            if (!has_post_thumbnail($this->post->ID)) {
-                continue;
-            }
-
-            $thumbnailId = get_post_thumbnail_id($this->post->ID);
-            $thumbnailPost = get_post($thumbnailId);
-
-            // Check if the translations already exists
-            if ($translation = $polylang->model->get_translation('post', $thumbnailId, $language_slug)) {
-                update_post_meta($translations[$language_slug], '_thumbnail_id', $translation);
-            }
-
-            $translationThumbnailPost = $thumbnailPost;
-
-            // Create a new attachment
-            $translationThumbnailPost->ID = null;
-            $translationThumbnailPost->post_parent = $translations[$language_slug];
-
-            $translationThumbnailId = wp_insert_attachment($translationThumbnailPost);
-
-            add_post_meta($translationThumbnailId, '_wp_attachment_metadata', get_post_meta($thumbnailId, '_wp_attachment_metadata', true));
-            add_post_meta($translationThumbnailId, '_wp_attached_file', get_post_meta($thumbnailId, '_wp_attached_file', true));
-            add_post_meta($translationThumbnailId, '_wp_attachment_image_alt', get_post_meta($thumbnailId, '_wp_attachment_image_alt', true));
-
-            $mediaTranslations = $polylang->model->get_translations('post', $thumbnailId);
-
-            if (!$mediaTranslations && $lang = $polylang->model->get_post_language($thumbnailId)) {
-                $mediaTranslations[$lang->slug] = $thumbnailId;
-            }
-
-            $mediaTranslations[$language_slug] = $translationThumbnailId;
-
-            pll_save_post_translations($mediaTranslations);
-            update_post_meta($translations[$language_slug], '_thumbnail_id', $translationThumbnailId);
-
-            do_action('bp_trapp_after_save_post_thumbnail', $translationThumbnailId, $thumbnailId);
+            $this->saveImages($translations[$languageSlug], $languageSlug);
         }
 
         pll_save_post_translations($translations);
+    }
+
+    public function saveImages($translationId, $languageSlug) {
+        $images = [];
+
+        if (has_post_thumbnail($this->post->ID)) {
+            $thumbnailId = get_post_thumbnail_id($this->post->ID);
+            $thumbnailPost = get_post($thumbnailId);
+
+            $images['featured_image'] = [
+                'id' => $thumbnailId,
+                'post' => $thumbnailPost,
+                'type' => 'meta',
+                'key' => '_thumbnail_id',
+            ];
+        }
+
+        $images = apply_filters('bp_trapp_save_images', $images, $this->post->ID);
+
+        foreach ($images as $image) {
+            $this->saveImage($translationId, $languageSlug, $image);
+        }
+    }
+
+    public function saveImage($translationId, $languageSlug, $image) {
+        global $polylang;
+
+        // Check if the translations already exists
+        if ($translation = $polylang->model->get_translation('post', $image['id'], $languageSlug)) {
+            update_post_meta($translationId, $image['key'], $translation);
+        }
+
+        $translationImagePost = $image['post'];
+
+        // Create a new attachment
+        $translationImagePost->ID = null;
+        $translationImagePost->post_parent = $translationId;
+
+        $translationImageId = wp_insert_attachment($translationImagePost);
+
+        add_post_meta($translationImageId, '_wp_attachment_metadata', get_post_meta($image['id'], '_wp_attachment_metadata', true));
+        add_post_meta($translationImageId, '_wp_attached_file', get_post_meta($image['id'], '_wp_attached_file', true));
+        add_post_meta($translationImageId, '_wp_attachment_image_alt', get_post_meta($image['id'], '_wp_attachment_image_alt', true));
+
+        $mediaTranslations = $polylang->model->get_translations('post', $image['id']);
+
+        if (!$mediaTranslations && $lang = $polylang->model->get_post_language($image['id'])) {
+            $mediaTranslations[$lang->slug] = $image['id'];
+        }
+
+        $mediaTranslations[$languageSlug] = $translationImageId;
+
+        pll_save_post_translations($mediaTranslations);
+        update_post_meta($translationId, $image['key'], $translationImageId);
+
+        do_action('bp_trapp_after_save_post_image', $translationImageId, $image['id']);
     }
 }

--- a/src/Bonnier/WP/Trapp/Admin/Polylang/MetaBox.php
+++ b/src/Bonnier/WP/Trapp/Admin/Polylang/MetaBox.php
@@ -55,21 +55,19 @@ class MetaBox
      */
     public static function polylangMetaBoxRender($post, $metabox)
     {
-        global $polylang;
-
         $post_id = $post->ID;
         $post_type = $metabox['args']['post_type'];
 
-        if ($lg = $polylang->model->get_post_language($post_id)) {
+        if ($lg = PLL()->model->post->get_language($post_id)) {
             $lang = $lg;
         } elseif (!empty($_GET['new_lang'])) {
-            $lang = $polylang->model->get_language($_GET['new_lang']);
+            $lang = PLL()->model->get_language($_GET['new_lang']);
         } else {
-            $lang = $polylang->pref_lang;
+            $lang = PLL()->pref_lang;
         }
 
         $text_domain = Plugin::TEXT_DOMAIN;
-        $languages = $polylang->model->get_languages_list();
+        $languages = PLL()->model->get_languages_list();
         $pll_dropdown = new PLL_Walker_Dropdown();
         $dropdown = $pll_dropdown->walk($languages, array(
             'name'     => 'post_lang_choice',
@@ -81,7 +79,7 @@ class MetaBox
         $masterLink = '';
 
         foreach ($languages as $language) {
-            $languagePost = $polylang->model->get_translation('post', $post_id, $language);
+            $languagePost = PLL()->model->post->get_translation($post_id, $language);
 
             if (!$languagePost) {
                 continue;

--- a/src/Bonnier/WP/Trapp/Admin/Post/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Post/Events.php
@@ -327,8 +327,8 @@ class Events
 
         if (!empty($new_fields)) {
             foreach ($new_fields as $new_field) {
-                $field = TranslationField::fromArray($field);
-                $service->addField($field);
+                $new_field = TranslationField::fromArray($new_field);
+                $service->addField($new_field);
             }
         }
 

--- a/src/Bonnier/WP/Trapp/Admin/Post/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Post/Events.php
@@ -153,9 +153,7 @@ class Events
             return;
         }
 
-        global $polylang;
-
-        $translations = $polylang->model->get_translations('post', $this->postId);
+        $translations = pll_get_post_translations($this->postId);
 
         if (empty($translations)) {
             return;
@@ -198,8 +196,6 @@ class Events
      */
     public function createTrappRevision()
     {
-        global $polylang;
-
         if (empty($_POST['trapp_tr_lang']) && !$this->hasPostTranslations()) {
             return;
         }
@@ -251,7 +247,7 @@ class Events
 
         foreach ($languages as $trapp_lang) {
             $trapp_lang = esc_attr($trapp_lang);
-            $trapp_lang = $polylang->model->get_language($trapp_lang);
+            $trapp_lang = PLL()->model->get_language($trapp_lang);
 
             if (!$trapp_lang) {
                 continue;
@@ -283,7 +279,6 @@ class Events
     public function updateTrappRevision()
     {
         // TODO Reminds alot of the insert flow so maybe merge into a common method
-        global $polylang;
 
         $service = new ServiceTranslation;
         $service = $service->getById($this->trappId);
@@ -345,7 +340,7 @@ class Events
         if (!empty($_POST['trapp_tr_lang'])) {
             foreach ($_POST['trapp_tr_lang'] as $trapp_lang => $active) {
                 $trapp_lang = esc_attr($trapp_lang);
-                $trapp_lang = $polylang->model->get_language($trapp_lang);
+                $trapp_lang = PLL()->model->get_language($trapp_lang);
 
                 if (!$trapp_lang) {
                     continue;
@@ -429,10 +424,8 @@ class Events
 
     public function getPostTranslations()
     {
-        global $polylang;
-
         $language = pll_get_post_language($this->postId);
-        $translations = $polylang->model->get_translations('post', $this->postId);
+        $translations = pll_get_post_translations($this->postId);
 
         if (array_key_exists($language, $translations)) {
             unset($translations[$language]);

--- a/src/Bonnier/WP/Trapp/Core/Endpoints.php
+++ b/src/Bonnier/WP/Trapp/Core/Endpoints.php
@@ -38,7 +38,21 @@ class Endpoints extends WP_REST_Controller
             'callback'            => array( $this, 'updateTrapp' ),
             'permission_callback' => array( $this, 'updateTrappPermissions' ),
         ]);
+        // TODO Remove debug
+        register_rest_route($namespace, '/translation_callbacks', [
+            'methods'             => WP_REST_Server::READABLE,
+            'callback'            => array( $this, 'translationCallbacks' ),
+        ]);
     }
+
+    // TODO Remove debug
+    public function translationCallbacks()
+    {
+    #    $this->htmlHeader();
+    #    ddd(get_option('bp_trapp_test_callback', array()));
+        return get_option('bp_trapp_test_callback', array());
+    }
+
 
     public function getNameSpace() {
         return sprintf('%s/v%d', self::PREFIX, self::VERSION);
@@ -49,6 +63,18 @@ class Endpoints extends WP_REST_Controller
         $request = $this->getFromCallback();
         $trappId = $request->getId();
         $post = $this->getPostByTrappId($trappId);
+
+        // TODO Remove debug
+        $name = 'bp_trapp_test_callback';
+        $option = get_option($name, []);
+        $entry = [
+            'request' => $request,
+            'post' => $_POST,
+            'raw' => file_get_contents('php://input'),
+        ];
+        array_unshift($option, $entry);
+        update_option($name, $option);
+        // TODO End debug
 
         if (!$post) {
             return false; // Or like "Post not found"
@@ -197,10 +223,6 @@ class Endpoints extends WP_REST_Controller
         $request = ServiceTranslation::fromCallback('', '', $json);
 
         return $request;
-    }
-
-    public function testArray() {
-        return get_option('bp_trapp_test_callback');
     }
 
     public function htmlHeader() {

--- a/src/Bonnier/WP/Trapp/Core/Endpoints.php
+++ b/src/Bonnier/WP/Trapp/Core/Endpoints.php
@@ -59,7 +59,7 @@ class Endpoints extends WP_REST_Controller
 
     public function updateTrapp()
     {
-        $this->htmlHeader();
+        #$this->htmlHeader();
 
         $request = $this->getFromCallback();
         $trappId = $request->getId();

--- a/src/Bonnier/WP/Trapp/Core/Endpoints.php
+++ b/src/Bonnier/WP/Trapp/Core/Endpoints.php
@@ -69,6 +69,9 @@ class Endpoints extends WP_REST_Controller
         $option = get_option($name, []);
         $entry = [
             'request' => $request,
+            'time' => current_time('mysql'),
+            'trappID' => $trappId,
+            'wpPost' => $post,
             'post' => $_POST,
             'raw' => file_get_contents('php://input'),
         ];

--- a/src/Bonnier/WP/Trapp/Core/Mappings.php
+++ b/src/Bonnier/WP/Trapp/Core/Mappings.php
@@ -40,12 +40,16 @@ class Mappings
                         'label' => 'Post Thumbnail Title',
                         'value' => $thumbnailPost->post_title,
                     ],
-                    'alt' => [
-                        'label' => 'Post Thumbnail Alt',
-                        'value' => get_post_meta($thumbnailId, '_wp_attachment_image_alt', true)
-                    ]
                 ]
             ];
+
+            $alt = get_post_meta($thumbnailId, '_wp_attachment_image_alt', true);
+            if ($alt) {
+                $translationGroups['post_thumbnail']['fields']['alt'] = [
+                    'label' => 'Post Thumbnail Alt',
+                    'value' => $alt,
+                ];
+            }
         }
 
         return apply_filters('bp_trapp_translation_groups', $translationGroups, $postId, $post);

--- a/src/Bonnier/WP/Trapp/Core/Mappings.php
+++ b/src/Bonnier/WP/Trapp/Core/Mappings.php
@@ -21,10 +21,12 @@ class Mappings
                 'post_title' => [
                     'label' => 'Post Title',
                     'value' => $post->post_title,
+                    'type' => 'wp_post',
                 ],
                 'post_content' => [
                     'label' => 'Post Body',
                     'value' => $post->post_content,
+                    'type' => 'wp_post',
                 ]
             ]
         ];
@@ -39,15 +41,18 @@ class Mappings
                     'post_title' => [
                         'label' => 'Post Thumbnail Title',
                         'value' => $thumbnailPost->post_title,
+                        'type' => 'post_thumbnail_wp_post'
                     ],
                 ]
             ];
 
             $alt = get_post_meta($thumbnailId, '_wp_attachment_image_alt', true);
+
             if ($alt) {
                 $translationGroups['post_thumbnail']['fields']['alt'] = [
                     'label' => 'Post Thumbnail Alt',
                     'value' => $alt,
+                    'type' => 'post_thumbnail_meta',
                 ];
             }
         }

--- a/views/admin/metabox-translations-post/translations.php
+++ b/views/admin/metabox-translations-post/translations.php
@@ -8,19 +8,19 @@
 
             <?php
 
-            $value = $polylang->model->get_translation('post', $post_id, $language);
+            $value = Pll()->model->post->get_translation($post_id, $language);
 
             if (!$value || $value == $post_id) { // $value == $post_id happens if the post has been (auto)saved before changing the language
                 $value = '';
             }
 
             if (isset($_GET['from_post'])) {
-                $value = $polylang->model->get_post((int)$_GET['from_post'], $language);
+                $value = PLL()->model->get_post((int)$_GET['from_post'], $language);
             }
 
             $add_link = sprintf(
                 '<a href="%1$s" class="pll_icon_add" title="%2$s"></a>',
-                esc_url($polylang->links->get_new_post_translation_link($post_id, $language)),
+                esc_url(PLL()->links->get_new_post_translation_link($post_id, $language)),
                 __('Add new', $text_domain)
             );
 
@@ -46,7 +46,7 @@
 
                     <?php if ($value) : ?>
 
-                        <td class="pll-edit-column"><?php echo $polylang->filters_post->edit_translation_link($value); ?></td>
+                        <td class="pll-edit-column"><?php echo PLL()->links->edit_post_translation_link($value); ?></td>
 
                     <?php if ($trapp_uri = get_post_meta($value, $trapp_link_key, true)) : ?>
                         <td class="pll-language-column"><?php printf('<a class="button" href="%1$s">%2$s</a>', esc_url($trapp_uri), __('Edit in TRAPP', $text_domain)); ?></td>


### PR DESCRIPTION
- Remove $polylang globals and use the `Pll()` singleton instead
- Copy images whenever a post is being translated
- Save callbacks and show these in an endpoint (for testing)
- Final solution for mappings and filters for get/save fields