### PR TITLE
Development

### DIFF
--- a/src/Bonnier/WP/Trapp/Admin/Main.php
+++ b/src/Bonnier/WP/Trapp/Admin/Main.php
@@ -220,6 +220,12 @@ class Main
             return;
         }
 
+        $screen = get_current_screen();
+
+        if (! $screen || $screen->base != 'post' ) {
+            return;
+        }
+
         if (empty($_POST['post_lang_choice'])) {
             // We will handle the translations instead of Polylang
             remove_action('save_post', array(Pll()->filters_post, 'save_post'), 21, 3);

--- a/src/Bonnier/WP/Trapp/Admin/Post/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Post/Events.php
@@ -6,6 +6,7 @@ use Bonnier\WP\Trapp\Plugin;
 use Bonnier\WP\Trapp\Core\Endpoints;
 use Bonnier\WP\Trapp\Core\Mappings;
 use Bonnier\WP\Trapp\Core\ServiceTranslation;
+use Bonnier\ServiceException;
 use Bonnier\Trapp\Translation\TranslationRevision;
 use Bonnier\Trapp\Translation\TranslationField;
 use DateTime;
@@ -125,19 +126,33 @@ class Events
         }
 
         $service = new ServiceTranslation;
-        $service = $service->getById($this->trappId);
-        $service->delete();
 
-        $row = $service->getRow();
+        try {
+            $service = $service->getById($this->trappId);
+            $service->delete();
 
-        /**
-         * Fired once a post with a TRAPP id has been deleted.
-         *
-         * @param int    $postId  Post ID.
-         * @param object $post WP_Post object of the deleted post.
-         * @param array  $row  Returned row from the Trapp request.
-         */
-        do_action('bp_after_delete_trapp', $this->postId, $this->post, $row);
+            $row = $service->getRow();
+
+            /**
+             * Fired once a post with a TRAPP id has been deleted.
+             *
+             * @param int    $postId  Post ID.
+             * @param object $post WP_Post object of the deleted post.
+             * @param array  $row  Returned row from the Trapp request.
+             */
+            do_action('bp_after_delete_trapp', $this->postId, $this->post, $row);
+
+        } catch (ServiceException $e) {
+            /**
+             * Fired once a post with a TRAPP id has been deleted and a ServiceException has been returned.
+             *
+             * @param int    $postId  Post ID.
+             * @param object $post    WP_Post object of the deleted post.
+             * @param object $e       Returned ServiceException.
+             */
+            do_action('bp_after_delete_trapp_exception', $this->postId, $this->post, $e);
+        }
+
     }
 
     /**


### PR DESCRIPTION
Seems like `Pll()->filters_post` is now set on some pages where save_post might be used. This was breaking the translation strings settings on the Polylang settings screen.

This fix check if the current screen base is post (which is what WP tries to POST to whenever it updates a post).