### PR TITLE
Updated Post/Events to get row correctly from new sdk

### DIFF
--- a/src/Bonnier/WP/Trapp/Admin/Post/Events.php
+++ b/src/Bonnier/WP/Trapp/Admin/Post/Events.php
@@ -129,9 +129,7 @@ class Events
 
         try {
             $service = $service->getById($this->trappId);
-            $service->delete();
-
-            $row = $service->getRow();
+            $row = $service->delete();
 
             /**
              * Fired once a post with a TRAPP id has been deleted.
@@ -281,10 +279,7 @@ class Events
             $service->addTranslatation($locale);
         }
 
-        $service->save();
-
-        // Get row data after data
-        $row = $service->getRow();
+        $row = $service->save();
 
         // Save Trapp ID
         add_post_meta($this->postId, self::TRAPP_META_KEY, $row->id);
@@ -402,10 +397,7 @@ class Events
             }
         }
 
-        $service->update();
-
-        // Get row data after data
-        $row = $service->getRow();
+        $row = $service->update();
 
         do_action('bp_trapp_after_save_post', $row, $this->post);
     }


### PR DESCRIPTION
Update to https://github.com/BenjaminMedia/bonnier-php-sdk/releases/tag/v3.0.5 of the sdk

```$service->getRow()``` returnerer altid en array nu, derfor kan den ikke accesses via object props ```$row->id``` hvis du ønsker at bruge object props metoden så kan du access'e dem direkte via $service instansen. like ```$service->id ``` efter du har kaldt ```$service->save()``` dette virker pga. magic methods.